### PR TITLE
Check for NULL Membership / No Default Role

### DIFF
--- a/src/Database/Database.sqlproj
+++ b/src/Database/Database.sqlproj
@@ -127,6 +127,5 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="Database.Local.publish.xml" />
-    <None Include="Database.Azure-Test.publish.xml" />
   </ItemGroup>
 </Project>

--- a/src/Database/Programmability/Stored Procedures/CreateMembership.sql
+++ b/src/Database/Programmability/Stored Procedures/CreateMembership.sql
@@ -58,15 +58,21 @@ BEGIN
 	WHERE R.[CommunityId] = @communityId
 	  AND R.[IsCommunityDefault] = @TRUE;
 
-	INSERT INTO [dbo].[MembershipRole]
-	(
-		[MembershipId],
-		[RoleId]
-	)
-	VALUES
-	(
-		@id,
-		@defaultRole
-	)
+	-- When creating the community, no roles have been defined for it.
+	IF @defaultRole IS NOT NULL
+		BEGIN
+		
+			INSERT INTO [dbo].[MembershipRole]
+			(
+				[MembershipId],
+				[RoleId]
+			)
+			VALUES
+			(
+				@id,
+				@defaultRole
+			)
+
+		END
 
 END

--- a/src/Website/Models/CommunityBasePageModel.cs
+++ b/src/Website/Models/CommunityBasePageModel.cs
@@ -24,6 +24,12 @@ namespace BrickAtHeart.Communities.Models
         public async Task<Community> GetCurrentCommunityForUser(ClaimsPrincipal user)
         {
             Membership membership = (await GetCurrentMembershipForUser(user));
+
+            if (membership == null)
+            {
+                return null;
+            }
+
             return (await communityStore.RetrieveCommunitiesByUserIdAsync(membership.UserId)).FirstOrDefault(c => c.Id == membership.CommunityId);
         }
 

--- a/src/Website/Pages/Shared/_CommunityContext.cshtml
+++ b/src/Website/Pages/Shared/_CommunityContext.cshtml
@@ -16,7 +16,7 @@
 
                     if (currentCommunity == null)
                     {
-                        <a asp-area="Community" asp-page="/Index">Join or Create a Community</a>
+                        <a asp-area="User" asp-page="/Account/Manage/Memberships">Join or Create a Community</a>
                     }
                     else
                     {


### PR DESCRIPTION
- When retrieving the user's current community, check for a null membership. The membership will be null if they haven't joined a community , yet.
- When creating a membership, check if the default role exists. If the community is also being created, no default role will be set, yet.