### PR TITLE
Automatically Grant OWNER All Rights

### DIFF
--- a/src/Database/Programmability/Stored Procedures/CreateRole.sql
+++ b/src/Database/Programmability/Stored Procedures/CreateRole.sql
@@ -10,6 +10,9 @@
 AS
 BEGIN
 
+	DECLARE @GRANTED	BIT = 1;
+	DECLARE @TRUE		BIT = 1;
+
 	INSERT INTO [dbo].[Role]
 	(
 		[RoleName],
@@ -29,14 +32,31 @@ BEGIN
 
 	SET @id = SCOPE_IDENTITY();
 
-	INSERT INTO [dbo].[RoleRight]
-	(
-		[RoleId],
-		[RightId]
-	)
-	SELECT
-		@id,
-		R.[Id]
-	FROM [dbo].[Right] R
+	IF @isSystemGeneratedOwner = @TRUE
+		BEGIN
+			INSERT INTO [dbo].[RoleRight]
+			(
+				[RoleId],
+				[RightId],
+				[State]
+			)
+			SELECT
+				@id,
+				R.[Id],
+				@GRANTED
+			FROM [dbo].[Right] R
+		END
+	ELSE
+		BEGIN
+			INSERT INTO [dbo].[RoleRight]
+			(
+				[RoleId],
+				[RightId]
+			)
+			SELECT
+				@id,
+				R.[Id]
+			FROM [dbo].[Right] R
+		END
 
 END


### PR DESCRIPTION
If the role being created is the system-generated owner (i.e. OWNER) then automatically grant all rights. Otherwise, the state for each right should be unset.